### PR TITLE
Dyn 483 misc arm template fixes

### DIFF
--- a/Dynamics/InRule.Dynamics.Service.json
+++ b/Dynamics/InRule.Dynamics.Service.json
@@ -256,7 +256,7 @@
             "inrule:crm:s2s:crmOrgUrl": "[parameters('orgUrl')]",
             "inrule:repository:licensing:licenseFolder": "D:\\home\\site\\wwwroot",
             "inrule:logging:level": "Warn",
-            "inrule:logging:appInsights:instrumentationKey": "[if(empty(parameters('appInsightsResourceName')), parameters('appInsightsInstrumentationKey'), reference(resourceId('Microsoft.Insights/components', parameters('appInsightsResourceName'))).InstrumentationKey)]"
+            "inrule:logging:appInsights:instrumentationKey": "[if(empty(parameters('appInsightsResourceName')), parameters('appInsightsInstrumentationKey'), reference(resourceId('Microsoft.Insights/components', parameters('appInsightsResourceName')), '2015-05-01').InstrumentationKey)]"
           }
         },
         {

--- a/Dynamics/InRule.Dynamics.Service.json
+++ b/Dynamics/InRule.Dynamics.Service.json
@@ -60,7 +60,7 @@
         "description": "Login password to connect to your InRule Rule Catalog"
       }
     },
-    "createAppServicePlan": {
+    "createOrUpdateAppServicePlan": {
       "type": "bool",
       "defaultValue": true,
       "metadata": {
@@ -109,7 +109,7 @@
         "description": "Defines what version of the InRule Execution Service to deploy"
       }
     },
-    "createAppInsightsResource": {
+    "createOrUpdateAppInsightsResource": {
       "type": "bool",
       "defaultValue": true,
       "metadata": {
@@ -120,14 +120,14 @@
       "type": "string",
       "defaultValue": "AppInsightsInstrumentationKey",
       "metadata": {
-        "description": "If createAppInsightsResource is set to false and you have an existing App Insights resource you'd like to use instead, provide the Instrumentation key here. If createAppInsightsResource is set to true, leave this blank and provide a value for 'appInsightsResourceName' instead"
+        "description": "If createOrUpdateAppInsightsResource is set to false and you have an existing App Insights resource you'd like to use instead, provide the Instrumentation key here. If createOrUpdateAppInsightsResource is set to true, leave this blank and provide a value for 'appInsightsResourceName' instead"
       }
     },
     "appInsightsResourceName": {
       "type": "string",
       "defaultValue": "[concat(parameters('appServiceName'),'AppInsights')]",
       "metadata": {
-        "description": "If createAppInsightsResource is set to true, define the name of the Application Insights resource to deploy here. If createAppInsightsResource is set to false, leave this field blank"
+        "description": "If createOrUpdateAppInsightsResource is set to true, define the name of the Application Insights resource to deploy here. If createOrUpdateAppInsightsResource is set to false, leave this field blank"
       }
     },
     "appInsightsLocation": {
@@ -158,7 +158,7 @@
       "properties": {}
     },
     {
-      "condition": "[parameters('createAppInsightsResource')]",
+      "condition": "[parameters('createOrUpdateAppInsightsResource')]",
       "name": "[variables('appInsightsResourceName')]",
       "type": "Microsoft.Insights/components",
       "apiVersion": "2015-05-01",
@@ -173,7 +173,7 @@
       "properties": {}
     },
     {
-      "condition": "[parameters('createAppServicePlan')]",
+      "condition": "[parameters('createOrUpdateAppServicePlan')]",
       "name": "AppServicePlanTemplate",
       "apiVersion": "2017-05-10",
       "type": "Microsoft.Resources/deployments",

--- a/InRule.Catalog.Service.json
+++ b/InRule.Catalog.Service.json
@@ -23,7 +23,7 @@
     },
     "catalogServicePlanName": {
       "type": "string",
-      "defaultValue": "[concat(parameters('appServiceName'),'Plan')]",
+      "defaultValue": "[concat(parameters('catalogServiceName'),'Plan')]",
       "metadata": {
         "description": "Name for the App Service Plan, defaulting to the value of the App Service's name with 'Plan' appended to the end"
       }

--- a/InRule.Catalog.Service.json
+++ b/InRule.Catalog.Service.json
@@ -14,7 +14,7 @@
         "description": "Name of the App Service resource the catalog manager will be installed on"
       }
     },
-    "createCatalogServicePlan": {
+    "createOrUpdateCatalogServicePlan": {
       "type": "bool",
       "defaultValue": true,
       "metadata": {
@@ -132,7 +132,7 @@
   },
   "resources": [
     {
-      "condition": "[parameters('createCatalogServicePlan')]",
+      "condition": "[parameters('createOrUpdateCatalogServicePlan')]",
       "name": "AppServicePlanTemplate",
       "apiVersion": "2017-05-10",
       "type": "Microsoft.Resources/deployments",

--- a/InRule.Catalog.Service.json
+++ b/InRule.Catalog.Service.json
@@ -128,7 +128,7 @@
   },
   "variables": {
     "use32Bit": "[or(equals(parameters('catalogServicePlanSkuName'), 'F1'), equals(parameters('catalogServicePlanSkuName'), 'D1'))]",
-    "catalogServicePlanName": "[if(empty(parameters('catalogServicePlanName')), concat(parameters('catalogServicePlanName'),'Plan'), parameters('catalogServicePlanName'))]"
+    "catalogServicePlanName": "[if(empty(parameters('catalogServicePlanName')), concat(parameters('catalogServiceName'),'Plan'), parameters('catalogServicePlanName'))]"
   },
   "resources": [
     {

--- a/InRule.Catalog.Service.parameters.json
+++ b/InRule.Catalog.Service.parameters.json
@@ -1,35 +1,39 @@
 {
-  "catalogServiceName": {
-    "value": "{catalogAppService}"
-  },
-  "catalogManagerServiceName": {
-    "value": "{catalogManagerAppService}"
-  },
-  "catalogServicePlanSkuName": {
-    "value": "B1"
-  },
-  "catalogSqlServerName": {
-    "value": "{catalogsqldbservername}"
-  },
-  "catalogSqlServerUsername": {
-    "value": "{sqlDbServerUser}"
-  },
-  "catalogSqlServerPassword": {
-    "value": "{sqlDbServerPassword}"
-  },
-  "catalogSqlDbName": {
-    "value": "{catalogSqlDbName}"
-  },
-  "catalogSqlDbEdition": {
-    "value": "Basic"
-  },
-  "catalogSqlDbPerformanceLevel": {
-    "value": "Basic"
-  },
-  "inRuleVersion": {
-    "value": "5.6.0"
-  },
-  "catalogServicePlanName": {
-    "value": ""
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "catalogServiceName": {
+      "value": "{catalogAppService}"
+    },
+    "catalogManagerServiceName": {
+      "value": "{catalogManagerAppService}"
+    },
+    "catalogServicePlanSkuName": {
+      "value": "B1"
+    },
+    "catalogSqlServerName": {
+      "value": "{catalogsqldbservername}"
+    },
+    "catalogSqlServerUsername": {
+      "value": "{sqlDbServerUser}"
+    },
+    "catalogSqlServerPassword": {
+      "value": "{sqlDbServerPassword}"
+    },
+    "catalogSqlDbName": {
+      "value": "{catalogSqlDbName}"
+    },
+    "catalogSqlDbEdition": {
+      "value": "Basic"
+    },
+    "catalogSqlDbPerformanceLevel": {
+      "value": "Basic"
+    },
+    "inRuleVersion": {
+      "value": "5.6.0"
+    },
+    "catalogServicePlanName": {
+      "value": ""
+    }
   }
 }

--- a/InRule.Runtime.Service.json
+++ b/InRule.Runtime.Service.json
@@ -8,7 +8,7 @@
         "description": "Name of the App Service resource the execution service will be installed on"
       }
     },
-    "createExecutionServicePlan": {
+    "createOrUpdateExecutionServicePlan": {
       "type": "bool",
       "defaultValue": true,
       "metadata": {
@@ -76,7 +76,7 @@
   },
   "resources": [
     {
-      "condition": "[parameters('createExecutionServicePlan')]",
+      "condition": "[parameters('createOrUpdateExecutionServicePlan')]",
       "name": "AppServicePlanTemplate",
       "apiVersion": "2017-05-10",
       "type": "Microsoft.Resources/deployments",

--- a/InRule.Runtime.Service.json
+++ b/InRule.Runtime.Service.json
@@ -72,7 +72,7 @@
   },
   "variables": {
     "use32Bit": "[or(equals(parameters('executionServicePlanSkuName'), 'F1'), equals(parameters('executionServicePlanSkuName'), 'D1'))]",
-    "executionServicePlanName": "[if(empty(parameters('executionServicePlanName')), concat(parameters('executionServicePlanName'),'Plan'), parameters('executionServicePlanName'))]"
+    "executionServicePlanName": "[if(empty(parameters('executionServicePlanName')), concat(parameters('executionServiceName'),'Plan'), parameters('executionServicePlanName'))]"
   },
   "resources": [
     {

--- a/InRule.Runtime.Service.parameters.json
+++ b/InRule.Runtime.Service.parameters.json
@@ -1,17 +1,21 @@
 {
-  "executionServiceName": {
-    "value": "{inruleRuntimeAppService}"
-  },
-  "executionServicePlanSkuName": {
-    "value": "B1"
-  },
-  "catalogUri": {
-    "value": ""
-  },
-  "inRuleVersion": {
-    "value": "5.6.0"
-  },
-  "executionServicePlanName": {
-    "value": ""
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "executionServiceName": {
+      "value": "{inruleRuntimeAppService}"
+    },
+    "executionServicePlanSkuName": {
+      "value": "B1"
+    },
+    "catalogUri": {
+      "value": ""
+    },
+    "inRuleVersion": {
+      "value": "5.6.0"
+    },
+    "executionServicePlanName": {
+      "value": ""
+    }
   }
 }

--- a/Salesforce/InRule.Salesforce.Service.json
+++ b/Salesforce/InRule.Salesforce.Service.json
@@ -75,7 +75,7 @@
         "description": "Password used to secure the rule service. This same password will need to be provided to Salesforce during configuration"
       }
     },
-    "createAppServicePlan": {
+    "createOrUpdateAppServicePlan": {
       "type": "bool",
       "defaultValue": true,
       "metadata": {
@@ -124,7 +124,7 @@
         "description": "Defines what version of the InRule Execution Service to deploy"
       }
     },
-    "createAppInsightsResource": {
+    "createOrUpdateAppInsightsResource": {
       "type": "bool",
       "defaultValue": true,
       "metadata": {
@@ -135,14 +135,14 @@
       "type": "string",
       "defaultValue": "AppInsightsInstrumentationKey",
       "metadata": {
-        "description": "If createAppInsightsResource is set to false and you have an existing App Insights resource you'd like to use instead, provide the Instrumentation key here. If createAppInsightsResource is set to true, leave this blank and provide a value for 'appInsightsResourceName' instead"
+        "description": "If createOrUpdateAppInsightsResource is set to false and you have an existing App Insights resource you'd like to use instead, provide the Instrumentation key here. If createOrUpdateAppInsightsResource is set to true, leave this blank and provide a value for 'appInsightsResourceName' instead"
       }
     },
     "appInsightsResourceName": {
       "type": "string",
       "defaultValue": "[concat(parameters('appServiceName'),'AppInsights')]",
       "metadata": {
-        "description": "If createAppInsightsResource is set to true, define the name of the Application Insights resource to deploy here. If createAppInsightsResource is set to false, leave this field blank"
+        "description": "If createOrUpdateAppInsightsResource is set to true, define the name of the Application Insights resource to deploy here. If createOrUpdateAppInsightsResource is set to false, leave this field blank"
       }
     },
     "appInsightsLocation": {
@@ -166,7 +166,7 @@
   },
   "resources": [
     {
-      "condition": "[parameters('createAppInsightsResource')]",
+      "condition": "[parameters('createOrUpdateAppInsightsResource')]",
       "name": "[variables('appInsightsResourceName')]",
       "type": "Microsoft.Insights/components",
       "apiVersion": "2015-05-01",
@@ -177,17 +177,17 @@
       },
       "properties": {
       }
-    },    
+    },
     {
-      "condition": "[parameters('createAppServicePlan')]",
+      "condition": "[parameters('createOrUpdateAppServicePlan')]",
       "name": "AppServicePlanTemplate",
       "apiVersion": "2017-05-10",
       "type": "Microsoft.Resources/deployments",
       "resourceGroup": "[parameters('servicePlanResourceGroupName')]",
       "properties": {
-      "mode": "Incremental",
-      "template": {
-        "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
           "contentVersion": "1.0.0.0",
           "resources": [
             {
@@ -203,9 +203,9 @@
               }
             }
           ]
-          }
         }
-      },
+      }
+    },
       {
         "name": "[parameters('appServiceName')]",
         "type": "Microsoft.Web/sites",

--- a/Salesforce/InRule.Salesforce.Service.json
+++ b/Salesforce/InRule.Salesforce.Service.json
@@ -258,7 +258,7 @@
               "inrule:sf:ruleService:basicPwd": "[parameters('executionServiceBasicPassword')]",
               "inrule:repository:licensing:licenseFolder": "D:\\home\\site\\wwwroot",
               "inrule:logging:level": "Warn",
-              "inrule:logging:appInsights:instrumentationKey": "[if(empty(parameters('appInsightsResourceName')), parameters('appInsightsInstrumentationKey'), reference(resourceId('Microsoft.Insights/components', parameters('appInsightsResourceName'))).InstrumentationKey)]"
+              "inrule:logging:appInsights:instrumentationKey": "[if(empty(parameters('appInsightsResourceName')), parameters('appInsightsInstrumentationKey'), reference(resourceId('Microsoft.Insights/components', parameters('appInsightsResourceName')), '2015-05-01').InstrumentationKey)]"
             }
           }
         ]


### PR DESCRIPTION
Updated 'create'X parameters in arm template to be 'createOrUpdate'X to more accurately reflect their functionality. Added app insights api version to inrule:logging:appInsights:instrumentationKey property to resolve validation issue when createOrUpdateAppInsightsResource is set to false. Updated the azuredeploy.octopus.parameters.json to contain full json structure.